### PR TITLE
import DEFAULT_SERVER_DATE_FORMAT

### DIFF
--- a/mrp_brewing/models/sale.py
+++ b/mrp_brewing/models/sale.py
@@ -2,7 +2,7 @@
 # Part of Open Architechts Consulting sprl. See LICENSE file for full copyright and licensing details.
 from datetime import datetime, timedelta
 from openerp import api, fields, models, _, SUPERUSER_ID
-from openerp.tools import DEFAULT_SERVER_DATETIME_FORMAT
+from openerp.tools import DEFAULT_SERVER_DATE_FORMAT
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"


### PR DESCRIPTION
import DEFAULT_SERVER_DATE_FORMAT instead of DEFAULT_SERVER_DATE_FORMAT

`DEFAULT_SERVER_DATE_FORMAT` is used at lines 15 and 20 but only `DEFAULT_SERVER_DATETIME_FORMAT` is imported at line 5. Is this normal or a bug?