### PR TITLE
replace amount_total by amount_untaxed in view_order_tree

### DIFF
--- a/mrp_brewing/views/sale_view.xml
+++ b/mrp_brewing/views/sale_view.xml
@@ -30,6 +30,12 @@
             <field name="model">sale.order</field>
             <field name="inherit_id" ref="sale.view_order_tree"/>
             <field name="arch" type="xml">
+              <xpath expr="//field[@name='amount_total']" position="attributes">
+                <attribute name="invisible">True</attribute>
+              </xpath>
+              <field name="amount_total" position='after'>
+                <field name="amount_untaxed"/>
+              </field>
             	<field name="invoice_status" position="after">
             		<field name="delivery_done_date"/>
             		<field name="delivery_status"/>


### PR DESCRIPTION
Is it a good practice to use position="replace"?
Or should I insert amount_total after amount_total and make amount_total invisible?

ref:
https://gestion.coopiteasy.be/web#id=20&view_type=form&model=project.task&action=475&active_id=2