### PR TITLE
Modification esthétiques

### DIFF
--- a/resource_activity/reports/activity_report.xml
+++ b/resource_activity/reports/activity_report.xml
@@ -23,25 +23,22 @@
         <div class="row" tyle="position:relative; margin-top:50px" name="row2">
             <div class="coll-xs-6">
                 <h2>
-                <span>Activity Summary D-Day:</span>   <span t-field="o.description"/> <span t-field="o.date_start"/> 
+			<span style="border-bottom: 4pt solid #00B9E4;">Activity Summary D-Day: <t t-field="o.description"> </t> <t t-field="o.date_start" t-field-options='{"format": "d MMMM y"}'></t> </span>
                 </h2>                                                            
             </div>
         </div>
-        <div class="row" name="row3">
-            <div class="col-xs-6" style="border-bottom: 4pt solid #00B9E4;" name="soulignage"></div>
-        </div>
                         
-        <div class="row" name="row4">
+        <div class="row" name="row3">
             <div class="col-xs-6" name="clients">
                 <div class="row" name="clients-titre">
                     <h3>Client:</h3>
                 </div>
                 <div class="row" name="clients-nom">
-                    <h5>Name:</h5>
+                    <h4>Name:</h4>
                     <span t-if="o.partner_id.name" t-field="o.partner_id.name"/>
                 </div>
                 <div class="row" name="clients-participants">
-                    <h5>Expected participants:</h5>
+                    <h4>Expected participants:</h4>
                     <span t-field="o.registrations_expected"/>
                 </div>
             </div>
@@ -50,21 +47,21 @@
                     <h3>Activity:</h3>
                 </div>
                 <div class="row" name="activite-depart">
-                    <h5>Start time and place:</h5>
+                    <h4>Start time and place:</h4>
                     <span t-field="o.date_start"/> 
                     <span t-field="o.departure"/>
                 </div>
                 <div class="row" name="activite-arrival">
-                    <h5>End time and place:</h5>
+                    <h4>End time and place:</h4>
                     <span t-field="o.date_end"/>
                     <span t-field="o.arrival"/>
                 </div>            
                 <div class="row" name="activite-theme">
-                    <h5>Theme:</h5>
+                    <h4>Theme:</h4>
                     <span t-field="o.activity_theme"/>
                 </div>
                 <div class="row" name="activite-langue">
-                    <h5>Languages:</h5>
+                    <h4>Languages:</h4>
                     <t t-foreach="o.langs" t-as="lang">
                         <t t-if="lang">                 
                             <div t-field="lang.name"/>
@@ -74,7 +71,7 @@
                 </div>
             </div>
         </div>
-        <div class="row" name="row5" style="position:relative;top:10px;">
+        <div class="row" name="row4" style="position:relative;top:10px;">
             <div class="col-xs-12">
                 <h3> Participants and resources </h3>
                 <table class="table table-striped border-easymy-coop" style="width:90%;align:center;">
@@ -103,7 +100,7 @@
                </div>
            </div> 
         </div>
-        <div class="row" name="raw6" style="margin-top:5px">
+        <div class="row" name="row5" style="margin-top:5px">
            <div class="col-xs-12" name="comments" style="border: medium dashed #00B9E4;" >
            <h2 style="margin-top:5px">Comments</h2>
            <p t-field="o.comment" name="comments-field" style="font-size: 16px;">


### PR DESCRIPTION
Salut Houssine,
Voici quelques menus changements, à savoir: 

-  Soulignage directement sur span du titre afin que le soulignage ait la même longueur que le texte.
-  Suppression de la row4 qui servait qu'au soulignage
-  Formatage de la date du titre 
-  Passage des sous-titre des sections Client et Activité en h4 pour une meilleure hiérarchie du contenu.