### PR TITLE
[FIX] display untaxed amount rather than taxed

### DIFF
--- a/mrp_brewing/models/partner.py
+++ b/mrp_brewing/models/partner.py
@@ -2,19 +2,37 @@
 
 from openerp import api, fields, models
 
+
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    last_order = fields.Date(compute="compute_last_order_date", string="Last Order", store=True) 
-    
+    last_order = fields.Date(
+        string="Last Order",
+        compute="compute_last_order_date",
+        store=True
+    )
+
+    last_contact_date = fields.Date(
+        string="Last Contact Date"
+    )
+
+    last_contact_comment = fields.Char(
+        string="Last Contact Comment"
+    )
+
     @api.multi
     @api.depends('sale_order_ids')
     def compute_last_order_date(self):
         for partner in self:
-            partner_orders = partner.sale_order_ids.filtered(lambda r: r.state not in ['cancel','exception'])
-            childs_orders = partner.mapped('child_ids.sale_order_ids').filtered(lambda r: r.state not in ['cancel','exception'])
+            partner_orders = (
+                partner
+                .sale_order_ids
+                .filtered(lambda r: r.state not in ['cancel', 'exception']))
+            childs_orders = (
+                partner
+                .mapped('child_ids.sale_order_ids')
+                .filtered(lambda r: r.state not in ['cancel', 'exception']))
             partner_orders = partner_orders + childs_orders
             partner_orders.sorted()
             if len(partner_orders) > 0:
                 partner.last_order = partner_orders[0].date_order
-                

--- a/mrp_brewing/views/partner_view.xml
+++ b/mrp_brewing/views/partner_view.xml
@@ -6,8 +6,12 @@
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_tree"/>
             <field name="arch" type="xml">
+            <xpath expr="//field[@name='email']" position="attributes">
+              <attribute name="invisible">True</attribute>
+            </xpath>
             	<field name="email" position="after">
             		<field name="last_order"/>
+                <field name='last_contact_date'/>
             	</field>
             </field>
         </record>
@@ -19,6 +23,8 @@
             <field name="arch" type="xml">
             	<field name="category_id" position="before">
             		<field name="last_order"/>
+                <field name='last_contact_date'/>
+                <field name='last_contact_comment'/>
             	</field>
             </field>
         </record>

--- a/mrp_brewing/views/sale_view.xml
+++ b/mrp_brewing/views/sale_view.xml
@@ -74,7 +74,7 @@
          <field name="product_id" type="row"/>
          <field name="date" interval="month" type="col"/>
          <field name="qty_invoiced" type="measure"/>
-         <field name="price_total" type="measure"/>
+         <field name="price_subtotal" type="measure"/>
        </pivot>
      </field>
     </record>


### PR DESCRIPTION
In sale report, display untaxed amount rather than taxed amount.

Is price_subtotal actually the untaxed amount? I noticed it with the
following query:

```sql
roke@/tmp:renard> select
                    price_total, price_subtotal, price_tax, price_total - price_tax
                  from sale_order_line
                  limit 5
+---------------+------------------+-------------+------------+
| price_total   | price_subtotal   | price_tax   | ?column?   |
|---------------+------------------+-------------+------------|
| 35.43         | 29.28            | 6.15        | 29.28      |
| 31.07         | 25.68            | 5.39        | 25.68      |
| 36.0          | 29.75            | 6.25        | 29.75      |
| 36.0          | 29.75            | 6.25        | 29.75      |
| 31.07         | 25.68            | 5.39        | 25.68      |
+---------------+------------------+-------------+------------+
```