### PR TITLE
add number of sold crates per order and month

### DIFF
--- a/mrp_brewing/data/cron.xml
+++ b/mrp_brewing/data/cron.xml
@@ -11,4 +11,17 @@
             <field name="args">()</field>
         </record>
     </data>
+
+    <data noupdate="0">
+        <record id="ir_cron_batch_partner_compute_sales_statistics" model="ir.cron">
+            <field name="name">MRP Brewing - Batch Compute Sale Statistics</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False" />
+            <field name="model">res.partner</field>
+            <field name="function">_batch_compute_sales_statistics</field>
+            <field name="args">()</field>
+        </record>
+    </data>
 </odoo>

--- a/mrp_brewing/models/partner.py
+++ b/mrp_brewing/models/partner.py
@@ -3,12 +3,93 @@
 from openerp import api, fields, models
 import datetime as dt
 
+_parse_date = fields.Datetime.from_string
+
+
+def _last_year():
+    return dt.datetime.today() - dt.timedelta(days=365)
+
+
+def filter_last_year_orders(partner_orders):
+    last_year_orders = partner_orders.filtered(
+        lambda po: _parse_date(po.date_order) > _last_year()
+    )
+    return last_year_orders
+
+
+def compute_last_order(partner_orders):
+    partner_orders = partner_orders.sorted()
+    if len(partner_orders) > 0:
+        return partner_orders[0].date_order
+    else:
+        return None
+
+
+def compute_sale_frequency(partner_orders):
+    partner_orders = filter_last_year_orders(partner_orders)
+    order_dates = partner_orders.mapped('date_order')
+    order_dates = map(_parse_date, order_dates)
+    order_dates = list(sorted(order_dates))
+
+    if len(order_dates) >= 2:
+        order_date_deltas = [
+            d2 - d1 for d1, d2 in zip(order_dates[:-1], order_dates[1:])
+        ]
+        delta_sum = sum(order_date_deltas, dt.timedelta(0))
+        average_delta = delta_sum / len(order_date_deltas)
+
+        return "%s days" % average_delta.days
+
+    else:
+        return None
+
+
+def compute_crate_per_order(partner_orders):
+    partner_orders = filter_last_year_orders(partner_orders)
+    crate_lines = (
+        partner_orders
+        .mapped('order_line')
+        .filtered(lambda ol: ol.product_id.is_crate))
+
+    if crate_lines:
+        nb_crates = sum(crate_lines.mapped('qty_invoiced'))
+        return nb_crates / len(partner_orders)
+    else:
+        return None
+
+
+def compute_crate_per_month(partner_orders):
+    last_year_orders = filter_last_year_orders(partner_orders)
+
+    crate_lines = (
+        last_year_orders
+        .mapped('order_line')
+        .filtered(lambda ol: ol.product_id.is_crate))
+
+    if crate_lines:
+        nb_crates = sum(crate_lines.mapped('qty_invoiced'))
+
+        order_dates = map(_parse_date, partner_orders.mapped('date_order'))
+        first_order_date = sorted(order_dates, reverse=True).pop()
+
+        # average on the last 12 months if customer has ordered before the last
+        # 12 month. Compute average since the first order otherwise.
+        if first_order_date < _last_year():
+            nb_months = 12
+        else:
+            nb_months = ((dt.datetime.today() - first_order_date).days / 31) + 1
+
+        return nb_crates / nb_months
+    else:
+        return None
+
+
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
     last_order = fields.Date(
         string="Last Order",
-        compute="compute_last_order_date",
+        compute="_compute_sales_statistics",
         store=True
     )
 
@@ -22,15 +103,28 @@ class ResPartner(models.Model):
 
     sale_frequency = fields.Char(
         string="Sale Order Frequency",
-        compute="compute_last_order_date",
+        compute="_compute_sales_statistics",
         store=True,
-        help="Compute the average time between two orders over the last 12 "
-             "months."
+        help="Average time between two orders over the last 12 months."
+    )
+    
+    crate_per_order = fields.Float(
+        string="Crates Bought per Sale Order",
+        compute="_compute_sales_statistics",
+        store=True,
+        help="Average number of crates bought per order over the last 12 months."
+    )
+
+    crate_per_month = fields.Float(
+        string="Crates Bought per Month",
+        compute="_compute_sales_statistics",
+        store=True,
+        help="Average number of crates bought per month over the last 12 months."
     )
 
     @api.multi
     @api.depends('sale_order_ids')
-    def compute_last_order_date(self):
+    def _compute_sales_statistics(self):
         for partner in self:
             partner_orders = (
                 partner
@@ -41,27 +135,8 @@ class ResPartner(models.Model):
                 .mapped('child_ids.sale_order_ids')
                 .filtered(lambda r: r.state not in ['cancel', 'exception']))
             partner_orders = partner_orders + childs_orders
-            partner_orders = partner_orders.sorted()
 
-            # last orders
-            if len(partner_orders) > 0:
-                partner.last_order = partner_orders[0].date_order
-            else:
-                partner.last_order = None
-
-            # sale frequency
-            last_year = dt.datetime.today() - dt.timedelta(days=365)
-            order_dates = partner_orders.mapped('date_order')
-            order_dates = map(fields.Datetime.from_string, order_dates)
-            order_dates = filter(lambda d: d > last_year, order_dates)
-            order_dates = list(sorted(order_dates))
-
-            if len(order_dates) >= 2:
-                order_date_deltas = [d2 - d1 for d1, d2 in zip(order_dates[:-1], order_dates[1:])]
-                delta_sum = sum(order_date_deltas, dt.timedelta(0))
-                average_delta = delta_sum / len(order_date_deltas)
-
-                partner.sale_frequency = "%s days" % average_delta.days
-
-            else:
-                partner.sale_frequency = None
+            partner.last_order = compute_last_order(partner_orders)
+            partner.sale_frequency = compute_sale_frequency(partner_orders)
+            partner.crate_per_order = compute_crate_per_order(partner_orders)
+            partner.crate_per_month = compute_crate_per_month(partner_orders)

--- a/mrp_brewing/models/partner.py
+++ b/mrp_brewing/models/partner.py
@@ -140,3 +140,8 @@ class ResPartner(models.Model):
             partner.sale_frequency = compute_sale_frequency(partner_orders)
             partner.crate_per_order = compute_crate_per_order(partner_orders)
             partner.crate_per_month = compute_crate_per_month(partner_orders)
+
+    @api.model
+    def _batch_compute_sales_statistics(self):
+        partners = self.search([('customer', '=', True)])
+        partners._compute_sales_statistics()

--- a/mrp_brewing/models/product.py
+++ b/mrp_brewing/models/product.py
@@ -10,6 +10,7 @@ class ProductTemplate(models.Model):
     raw_material = fields.Boolean(string="Is raw material")
     finished_product = fields.Boolean(string="Is finished product")
     is_brewable = fields.Boolean(string="Is brewable")
+    is_crate = fields.Boolean(string="Is Crate", default=False)
     brew_product_sequence = fields.Many2one('ir.sequence', string="Brew product sequence")
     
     

--- a/mrp_brewing/views/partner_view.xml
+++ b/mrp_brewing/views/partner_view.xml
@@ -11,8 +11,10 @@
             </xpath>
             	<field name="email" position="after">
             		<field name="last_order"/>
-                <field name='last_contact_date'/>
-                <field name='sale_frequency'/>
+                    <field name='last_contact_date'/>
+                    <field name='sale_frequency'/>
+                    <field name='crate_per_order'/>
+                    <field name='crate_per_month'/>
             	</field>
             </field>
         </record>
@@ -24,8 +26,10 @@
             <field name="arch" type="xml">
             	<field name="category_id" position="before">
             		<field name="last_order"/>
-                <field name='last_contact_date'/>
-                <field name='last_contact_comment'/>
+                    <field name='last_contact_date'/>
+                    <field name='last_contact_comment'/>
+            		<field name="crate_per_order"/>
+            		<field name="crate_per_month"/>
             	</field>
             </field>
         </record>

--- a/mrp_brewing/views/product_view.xml
+++ b/mrp_brewing/views/product_view.xml
@@ -30,6 +30,10 @@
                         <field name="is_brewable"/>
                         <label for="is_brewable"/>
                     </div>
+                    <div>
+                        <field name="is_crate"/>
+                        <label for="is_crate"/>
+                    </div>
                 </xpath>
                 <field name="type" position="after">
                 	<field name="brew_product_sequence" attrs="{'invisible':[('is_brewable','=',False)],'required':[('is_brewable','=',True)]}"/>


### PR DESCRIPTION
- move all computation to `compute_sales_statistics`
- number of sold crates is the sum of sale_order_line.qty_invoiced
- nb crated ordred per month is computed over the last 12 months 
if customer has ordered before the last 12 month. It compute average 
since the first order otherwise.

spec: https://gestion.coopiteasy.be/web#id=219&view_type=form&model=project.task&action=475&active_id=2