### PR TITLE
[FIX] book resources over resource_allocation_start|end span

### DIFF
--- a/resource_activity/views/resource_activity_views.xml
+++ b/resource_activity/views/resource_activity_views.xml
@@ -82,8 +82,8 @@
 								<field name="without_resource_reg"/>
 								<field name="need_participation"/>
 								<field name="participation_product_id" attrs="{'invisible':[('need_participation','=',False)], 'required':[('need_participation','=',True)]}"/>
-								<field name="resource_allocation_start" attrs="{'readonly':[('set_allocation_span','=',False)]}"/>
-								<field name="resource_allocation_end" attrs="{'readonly':[('set_allocation_span','=',False)]}"/>
+								<field name="resource_allocation_start"/>
+								<field name="resource_allocation_end"/>
 								<field name="set_allocation_span"/>
 								<field name="need_delivery"/>
 								<field name="delivery_product_id" options="{'no_create': True}" attrs="{'invisible':[('need_delivery','=',False)], 'required':[('need_delivery','=',True)]}"/>


### PR DESCRIPTION
# Context

In #14, in `ResourceActivity` I added fields `resource_allocation_start` and `resource_allocation_end` filled based on `date_start`, `date_end` and `need_delivery`.

# Problem

These two fields are not taken into account when doing a booking.

# Changes

I noticed `ActivityRegistration.date_start` and `ActivityRegistration.date_end` is related to `ResourceActivity.date_start` and `ResourceActivity.date_end`. I am tempted to make this field relate to `resource_allocation_start` and end but it would then book human resources for the whole day as well.

Should I do a compute function? it seems overly complicated.