### PR TITLE
[BUG] resource is unavailable if date end is in the past

### DIFF
--- a/resource_planning/models/resource.py
+++ b/resource_planning/models/resource.py
@@ -70,14 +70,13 @@ class Resource(models.Model):
         self.check_dates(date_start, date_end)
         available_resources = self.filtered(lambda r: r.state == 'available')
         if location:
-            available_resources = available_resources.filtered(lambda r: r.location.id ==  location.id)
+            available_resources = available_resources.filtered(lambda r: r.location.id == location.id)
         available_resources_ids = available_resources.ids
 
         # assert start < end
         conflicting_allocation_domain = [
             ('resource_id', 'in', available_resources_ids),
             ('state', '!=', 'cancel'),
-            ('date_end', '>=', fields.Datetime.now()),
             '!',
                 '|', ('date_end', '<=', date_start),
                      ('date_start', '>=', date_end)


### PR DESCRIPTION
Problem
---

Resources appeared as available if they were in the past.

Fix
---

I chose to remove the condition on the date altogether. 
The users may want to fix allocation for past bookings.

I could add a warning for reservations in the past.