### PR TITLE
deactivate mail.thread on resource.allocation

### DIFF
--- a/resource_planning/models/resource.py
+++ b/resource_planning/models/resource.py
@@ -118,7 +118,7 @@ class Resource(models.Model):
 class ResourceAllocation(models.Model):
     _name = "resource.allocation"
     
-    _inherit = ['mail.thread']
+    # _inherit = ['mail.thread']
     
     name = fields.Many2one(related="partner_id")
     serial_number = fields.Char(related="resource_id.serial_number", string="Serial number")

--- a/resource_planning/models/resource.py
+++ b/resource_planning/models/resource.py
@@ -17,6 +17,7 @@ class ResourceCategory(models.Model):
     name = fields.Char(string="Category name", required=True)
     resources = fields.One2many('resource.resource', 'category_id', string="Resources")
 
+
 class Resource(models.Model):
     _name = 'resource.resource'
     _inherit = ['resource.resource', 'mail.thread']
@@ -29,11 +30,11 @@ class Resource(models.Model):
         return location
 
     category_id = fields.Many2one('resource.category', string="Category")
-    state = fields.Selection([('draft','Draft'),
-                              ('available','Available'),
-                              ('unavailable','Unavailable')],
+    state = fields.Selection([('draft', 'Draft'),
+                              ('available', 'Available'),
+                              ('unavailable', 'Unavailable')],
                              string="State", default='draft')
-    resource_type = fields.Selection([('user','Human'),('material','Material')],
+    resource_type = fields.Selection([('user', 'Human'), ('material', 'Material')],
                                       string="Resource Type", required=True, default="material")
     allocations = fields.One2many('resource.allocation', 'resource_id', string="Booking lines")
     serial_number = fields.Char(string="ID number")
@@ -62,7 +63,8 @@ class Resource(models.Model):
         if not date_start or not date_end:
             raise ValidationError((_("Error. Date start or date end aren't set")))
         elif date_end < date_start:
-            raise ValidationError((_("Error. End date is preceding start date. Please choose an end date after a start date ")))
+            raise ValidationError((_("Error. End date is preceding start date. Please choose an end date after a "
+                                     "start date ")))
         #elif date_start < fields.Datetime.now():
 
     @api.multi        
@@ -95,12 +97,12 @@ class Resource(models.Model):
         res_alloc = self.env['resource.allocation']
 
         vals = {
-            'date_start':date_start,
-            'date_end':date_end,
-            'date_lock':date_lock,
-            'state':allocation_type,
-            'partner_id':partner_id.id,
-            'location':location.id
+            'date_start': date_start,
+            'date_end': date_end,
+            'date_lock': date_lock,
+            'state': allocation_type,
+            'partner_id': partner_id.id,
+            'location': location.id
         }
 
         # we check again the availabilities in case in has been booked 
@@ -126,10 +128,10 @@ class ResourceAllocation(models.Model):
     resource_category_id = fields.Many2one(related='resource_id.category_id', string="Resource Category", store=True)
     date_start = fields.Datetime(string="Date start")
     date_end = fields.Datetime(string="Date end")
-    state = fields.Selection([('booked','Booked'),
-                             ('option','Option'),
-                             ('maintenance','Maintenance'),
-                             ('cancel','Cancel')],
+    state = fields.Selection([('booked', 'Booked'),
+                             ('option', 'Option'),
+                             ('maintenance', 'Maintenance'),
+                             ('cancel', 'Cancel')],
                             string="State", default='option')
     date_lock = fields.Date(string="Lock date",
                             help="If the booking type is option, it should be confirmed before the lock date expire")
@@ -139,7 +141,7 @@ class ResourceAllocation(models.Model):
     @api.multi
     def action_confirm(self):
         for allocation in self:
-            allocation.write({'state':'booked', 'date_lock':None})
+            allocation.write({'state': 'booked', 'date_lock': None})
 
     @api.multi
     def action_cancel(self):

--- a/resource_planning/views/resource_planning_views.xml
+++ b/resource_planning/views/resource_planning_views.xml
@@ -130,10 +130,10 @@
 			               	</group>
 		               	</group>
 		            </sheet>
-		            <div class="oe_chatter">
-	                    <field name="message_follower_ids" widget="mail_followers"/>
-	                    <field name="message_ids" widget="mail_thread"/>
-                	</div>
+		            <!--<div class="oe_chatter">-->
+	                    <!--<field name="message_follower_ids" widget="mail_followers"/>-->
+	                    <!--<field name="message_ids" widget="mail_thread"/>-->
+                	<!--</div>-->
                 </form>
             </field>
         </record>

--- a/resource_planning/wizard/allocate_resource_wizard.py
+++ b/resource_planning/wizard/allocate_resource_wizard.py
@@ -3,18 +3,19 @@
 from openerp import api, fields, models, _
 from openerp.exceptions import ValidationError, UserError
 
+
 class AllocateResourceWizard(models.TransientModel):
     _name = "allocate.resource.wizard"
     
     date_start = fields.Datetime(string="Date Start", required=True)
     date_end = fields.Datetime(string="Date end", required=True)
     resources = fields.Many2many('resource.resource', string="Resources")
-    allocation_type = fields.Selection([('booked','Book'),
-                                        ('option','Option'),
-                                        ('maintenance','Maintenance')],
+    allocation_type = fields.Selection([('booked', 'Book'),
+                                        ('option', 'Option'),
+                                        ('maintenance', 'Maintenance')],
                                         string="Allocation type", required=True)
-    resource_type = fields.Selection([('resource','Resource'),
-                                      ('category','Category')],
+    resource_type = fields.Selection([('resource', 'Resource'),
+                                      ('category', 'Category')],
                                       string="Allocate on", default="resource", required=True)
     resource_category_id = fields.Many2one('resource.category', string="Resource Category")
     checked_resources = fields.Boolean(string="Checked resources")
@@ -35,7 +36,7 @@ class AllocateResourceWizard(models.TransientModel):
         if self.checked_resources and self.resource_category_id:
             self.checked_resources = False
     
-    @api.onchange('date_start','date_end')
+    @api.onchange('date_start', 'date_end')
     def onchange_dates(self):
         if self.checked_resources and self.date_start and self.date_end:
             self.checked_resources = False
@@ -69,4 +70,11 @@ class AllocateResourceWizard(models.TransientModel):
     @api.multi
     def book_resource(self):
         if self.resources:
-            self.resources.allocate_resource(self.allocation_type, self.date_start, self.date_end, self.partner_id, self.location, self.date_lock)
+            self.resources.allocate_resource(
+                self.allocation_type,
+                self.date_start,
+                self.date_end,
+                self.partner_id,
+                self.location,
+                self.date_lock
+            )


### PR DESCRIPTION
ref [Bug lors de réservation "cannot follow twice the same object"](https://gestion.openarchitectsconsulting.com/web#id=79&view_type=form&model=project.issue)

Diagnostic:

- Contrainte SQL violée dans mail_followers.py:
  - ('mail_followers_res_partner_res_model_id_uniq', 'unique(res_model,res_id, Partner_id)', 'Error, a partner cannot follow twice the same object'),
  - DETAIL: Key (res_model, res_id, partner_id)=(resource.allocation, 400, 3) already exists.
- au moment de la création d'allocation de resource dans resource_planning/models/resource.py:113:
```
    for resource in self.browse(available_resource_ids):
        vals['resource_id'] = resource.id
        allocation = res_alloc.create(vals)
        allocation_ids.append(allocation.id)
```
Je ne trouve pas de solution propre à moins de modifier le module "mail" de Odoo. Le problème a été réparé dans Odoo 11.

Une solution qui fonctionne: désactiver le module mail.thread sur resource.allocation. C'est-à-dire désactiver le flux de message sur les pages Resource Allocation / Réservation de ressource.