### PR TITLE
Réservation de ressource : pouvoir voir l'activité liée

### DIFF
--- a/resource_activity/models/resource.py
+++ b/resource_activity/models/resource.py
@@ -5,6 +5,7 @@
 from openerp import _, api, fields, models
 from openerp.exceptions import ValidationError, UserError
 
+
 class ResourceCategory(models.Model):
     _inherit = 'resource.category'
     
@@ -21,8 +22,8 @@ class ProductProduct(models.Model):
 class ResourceLocation(models.Model):
     _inherit = 'resource.location'
 
-    guides = fields.One2many('res.partner','resource_location_guide', domain=[('is_guide','=',True)], string="Guides")
-    trainers = fields.One2many('res.partner','resource_location_trainer', domain=[('is_trainer','=',True)], string="Trainers")
+    guides = fields.One2many('res.partner', 'resource_location_guide', domain=[('is_guide', '=', True)], string="Guides")
+    trainers = fields.One2many('res.partner', 'resource_location_trainer', domain=[('is_trainer', '=', True)], string="Trainers")
 
 
 class ResourceAllocation(models.Model):
@@ -30,4 +31,3 @@ class ResourceAllocation(models.Model):
 
     activity_registration_id = fields.Many2one('resource.activity.registration', string="Activity registration", readonly=True)
     activity_id = fields.Many2one(related='activity_registration_id.resource_activity_id', string="Activity", readonly=True)
-

--- a/resource_activity/models/resource.py
+++ b/resource_activity/models/resource.py
@@ -29,5 +29,5 @@ class ResourceAllocation(models.Model):
     _inherit = 'resource.allocation'
 
     activity_registration_id = fields.Many2one('resource.activity.registration', string="Activity registration", readonly=True)
-    activity_id = fields.Many2one(related='activity_registration_id.resource_activity_id', string="Registrations", readonly=True)
+    activity_id = fields.Many2one(related='activity_registration_id.resource_activity_id', string="Activity", readonly=True)
 

--- a/resource_activity/views/resource_views.xml
+++ b/resource_activity/views/resource_views.xml
@@ -33,27 +33,25 @@
             </field>
         </record>
 
-		<!--<record id="resource_planning_resource_form" model="'ir.ui.view">-->
-			<!--<field name="name">resource.resource.form</field>-->
-			<!--<field name="model">resource.resource</field>-->
-			<!--<field name="inherit_id" ref="resource_planning.resource_planning_resource_form"/>-->
-			<!--<field name="arch" type="xml">-->
-				<!--<xpath expr="//page[@name='allocations']" position="replace">-->
-					<!--<page name="allocations" string="Allocations">-->
-						<!--<field name="allocations">-->
-							<!--<tree delete="false" create="false">-->
-								<!--<field name="partner_id"/>-->
-								<!--<field name="date_start"/>-->
-								<!--<field name="date_end"/>-->
-								<!--<field name="date_lock"/>-->
-								<!--<field name="state"/>-->
-								<!--<field name="activity_id"/>-->
-							<!--</tree>-->
-						<!--</field>-->
-					<!--</page>-->
-				<!--</xpath>-->
-			<!--</field>-->
-		<!--</record>-->
+		<record id="resource_planning_resource_form_inherit" model="ir.ui.view">
+			<field name="name">resource.resource.form</field>
+			<field name="model">resource.resource</field>
+			<field name="inherit_id" ref="resource_planning.resource_planning_resource_form"/>
+			<field name="arch" type="xml">
+				<xpath expr="//field[@name='allocations']" position="replace">
+					<field name="allocations">
+						<tree delete="false" create="false">
+							<field name="partner_id"/>
+							<field name="date_start"/>
+							<field name="date_end"/>
+							<field name="date_lock"/>
+							<field name="state"/>
+							<field name="activity_id"/>
+						</tree>
+					</field>
+            	</xpath>
+			</field>
+		</record>
 
 	</data>
 </odoo>

--- a/resource_activity/views/resource_views.xml
+++ b/resource_activity/views/resource_views.xml
@@ -32,5 +32,28 @@
             	</field>
             </field>
         </record>
+
+		<!--<record id="resource_planning_resource_form" model="'ir.ui.view">-->
+			<!--<field name="name">resource.resource.form</field>-->
+			<!--<field name="model">resource.resource</field>-->
+			<!--<field name="inherit_id" ref="resource_planning.resource_planning_resource_form"/>-->
+			<!--<field name="arch" type="xml">-->
+				<!--<xpath expr="//page[@name='allocations']" position="replace">-->
+					<!--<page name="allocations" string="Allocations">-->
+						<!--<field name="allocations">-->
+							<!--<tree delete="false" create="false">-->
+								<!--<field name="partner_id"/>-->
+								<!--<field name="date_start"/>-->
+								<!--<field name="date_end"/>-->
+								<!--<field name="date_lock"/>-->
+								<!--<field name="state"/>-->
+								<!--<field name="activity_id"/>-->
+							<!--</tree>-->
+						<!--</field>-->
+					<!--</page>-->
+				<!--</xpath>-->
+			<!--</field>-->
+		<!--</record>-->
+
 	</data>
 </odoo>

--- a/resource_planning/views/resource_planning_views.xml
+++ b/resource_planning/views/resource_planning_views.xml
@@ -140,10 +140,6 @@
 			               	</group>
 		               	</group>
 		            </sheet>
-		            <!--<div class="oe_chatter">-->
-	                    <!--<field name="message_follower_ids" widget="mail_followers"/>-->
-	                    <!--<field name="message_ids" widget="mail_thread"/>-->
-                	<!--</div>-->
                 </form>
             </field>
         </record>

--- a/resource_planning/views/resource_planning_views.xml
+++ b/resource_planning/views/resource_planning_views.xml
@@ -17,10 +17,10 @@
             </field>
         </record>
 
-        
-        <record id="resource.resource_resource_form" model="ir.ui.view">
-            <field name="name">resource.resource.form</field>
+        <record id="resource_planning_resource_form" model="ir.ui.view">
+            <field name="name">resource.planning.resource.form</field>
             <field name="model">resource.resource</field>
+            <field name="priority">15</field>
             <field name="arch" type="xml">
                 <form string="Resource">
                		<header>

--- a/resource_vehicule/views/resource_vehicule_views.xml
+++ b/resource_vehicule/views/resource_vehicule_views.xml
@@ -29,7 +29,7 @@
 		<record id="resource_vehicule_form" model="ir.ui.view">
             <field name="name">resource.resource.form</field>
             <field name="model">resource.resource</field>
-            <field name="inherit_id" ref="resource.resource_resource_form"/>
+            <field name="inherit_id" ref="resource_planning.resource_planning_resource_form"/>
             <field name="arch" type="xml">
             	<group name="category" position="after">
 					<group name="vehicule" string="Vehicule Info" attrs="{'invisible':[('vehicule_type','!=','bike')]}">


### PR DESCRIPTION
ref [Réservation de ressource : pouvoir voir l'activité liée](https://gestion.openarchitectsconsulting.com/web#id=73&view_type=form&model=project.issue&action=346&active_id=21)

1) rename resource.allocation.activity_id label from Registrations to Activity
2) refactor resource.resource form view (was overrifing standard view)
3) add activity column in resource.allocations tree in resource form