### PR TITLE
Bloquer les encodages par journaux (achat/vente)

### DIFF
--- a/account_journal_lock_date/__init__.py
+++ b/account_journal_lock_date/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/account_journal_lock_date/__openerp__.py
+++ b/account_journal_lock_date/__openerp__.py
@@ -21,7 +21,8 @@
     # any module necessary for this one to work correctly
     'depends': [
         'base',
-        'account'
+        'account',
+        'account_permanent_lock_move',
     ],
 
     # always loaded

--- a/account_journal_lock_date/__openerp__.py
+++ b/account_journal_lock_date/__openerp__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "Account Journal Lock Date",
+
+    'summary': """
+        Lock each journal independently""",
+
+    'description': """
+        Lock each journal independently.
+        This is a backport of version 10.0 module of the same name by Stéphane Bidoul.
+        
+        https://github.com/OCA/account-financial-tools/tree/10.0/account_journal_lock_date
+    """,
+
+    'author': "Coop IT Easy SCRL",
+    'website': "http://www.coopiteasy.be",
+
+    'category': 'Accounting & Finance',
+    'version': '9.0.0.1',
+
+    # any module necessary for this one to work correctly
+    'depends': [
+        'base',
+        'account'
+    ],
+
+    # always loaded
+    'data': [
+        'views/journal_lock_views.xml',
+    ],
+}

--- a/account_journal_lock_date/models/__init__.py
+++ b/account_journal_lock_date/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import models

--- a/account_journal_lock_date/models/models.py
+++ b/account_journal_lock_date/models/models.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models, fields, api
+from openerp.exceptions import ValidationError, UserError
+
+
+class AccountJournal(models.Model):
+    _inherit = 'account.journal'
+
+    journal_lock_date = fields.Date(
+        name='Lock Date',
+        help="Moves cannot be entered nor modified in this "
+             "journal prior to the lock date, unless the user "
+             "has the Adviser role.",
+    )
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    @api.multi
+    def _check_lock_date(self):
+        res = super(AccountMove, self)._check_lock_date()
+        for move in self:
+            lock_date = move.journal_id.journal_lock_date
+            if lock_date and move.date <= lock_date:
+                raise JournalLockDateError("You cannot add/modify entries "
+                                               "prior to and inclusive of the "
+                                               "journal lock date "
+                                               " %s" % lock_date)
+        return res
+
+
+class JournalLockDateError(ValidationError):
+    pass

--- a/account_journal_lock_date/tests/__init__.py
+++ b/account_journal_lock_date/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Robin Keunen, Coop IT Easy SCRL fs
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from . import test_journal_lock_date

--- a/account_journal_lock_date/tests/test_journal_lock_date.py
+++ b/account_journal_lock_date/tests/test_journal_lock_date.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 ACSONE SA/NV
+# Copyright 2018 Coop IT Easy SCRL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from datetime import date, timedelta
+
+from openerp import fields, tools
+from openerp.modules import get_module_resource
+from openerp.tests import common
+
+from ..models.models import JournalLockDateError
+
+
+class TestJournalLockDate(common.TransactionCase):
+
+    def setUp(self):
+        super(TestJournalLockDate, self).setUp()
+        tools.convert_file(self.cr, 'account',
+                           get_module_resource('account', 'test',
+                                               'account_minimal_test.xml'),
+                           {}, 'init', False, 'test')
+        self.account_move_obj = self.env["account.move"]
+        self.account_move_line_obj = \
+            self.env["account.move.line"]
+
+        self.company_id = self.ref('base.main_company')
+        self.partner = self.browse_ref("base.res_partner_2")
+        self.account = self.browse_ref("account.a_recv")
+        self.account2 = self.browse_ref("account.a_expense")
+        self.journal = self.browse_ref("account.bank_journal")
+
+    def create_move(self):
+        """create a move and post it"""
+        move = self.account_move_obj.create({
+            'date': fields.Date.today(),
+            'journal_id': self.journal.id,
+            'line_ids': [
+                (0, 0, {
+                    'account_id': self.account.id,
+                    'credit': 1000.0,
+                    'name': 'Credit line'}),
+                (0, 0, {
+                    'account_id': self.account2.id,
+                    'debit': 1000.0,
+                    'name': 'Debit line',
+            })]
+        })
+        move.post()
+        return move
+
+    def test_create_account_move(self):
+        self.env.user.write({
+            'groups_id': [(3, self.ref('account.group_account_manager'))],
+        })
+        self.assertFalse(self.env.user.has_group(
+            'account.group_account_manager'))
+
+        self.create_move()
+
+    def test_create_account_move_on_locked_journal(self):
+        """Test that the move cannot be created."""
+        # lock journal
+
+        self.journal.journal_lock_date = fields.Date.today()
+
+        with self.assertRaises(JournalLockDateError):
+            self.account_move_obj.create({
+                'date': fields.Date.today(),
+                'journal_id': self.journal.id,
+                'line_ids': [(0, 0, {
+                    'account_id': self.account.id,
+                    'credit': 1000.0,
+                    'name': 'Credit line',
+                }), (0, 0, {
+                    'account_id': self.account2.id,
+                    'debit': 1000.0,
+                    'name': 'Debit line',
+                })]
+            })
+
+    def test_update_account_move_on_locked_journal(self):
+        """Test that the move cannot be written"""
+        move = self.create_move()
+        self.journal.journal_lock_date = fields.Date.today()
+
+        with self.assertRaises(JournalLockDateError):
+            move.write({'name': 'TEST'})
+
+    def test_cancel_account_move_on_locked_journal(self):
+        """Test that the move cannot be cancelled"""
+        move = self.create_move()
+        self.journal.journal_lock_date = fields.Date.today()
+        with self.assertRaises(JournalLockDateError):
+            move.button_cancel()
+
+    def test_update_account_move_on_unlocked_journal(self):
+        # create a move after their lock date and post it
+        self.journal.journal_lock_date = fields.Date.today()
+        tomorrow = date.today() + timedelta(days=1)
+        move = self.account_move_obj.create({
+            'date': tomorrow,
+            'journal_id': self.journal.id,
+            'line_ids': [(0, 0, {
+                'account_id': self.account.id,
+                'credit': 1000.0,
+                'name': 'Credit line',
+            }), (0, 0, {
+                'account_id': self.account2.id,
+                'debit': 1000.0,
+                'name': 'Debit line',
+            })]
+        })
+        move.post()
+
+    # def test_journal_lock_date_adviser(self):
+    #     """ The journal lock date is ignored for Advisers """
+    #     self.env.user.write({
+    #         'groups_id': [(4, self.ref('account.group_account_manager'))],
+    #     })
+    #     self.assertTrue(self.env.user.has_group(
+    #         'account.group_account_manager'))
+    #
+    #     # lock journal
+    #     self.journal.journal_lock_date = fields.Date.today()
+    #
+    #     # advisers can create moves before or on the lock date
+    #     self.account_move_obj.create({
+    #         'date': fields.Date.today(),
+    #         'journal_id': self.journal.id,
+    #         'line_ids': [(0, 0, {
+    #             'account_id': self.account.id,
+    #             'credit': 1000.0,
+    #             'name': 'Credit line',
+    #         }), (0, 0, {
+    #             'account_id': self.account2.id,
+    #             'debit': 1000.0,
+    #             'name': 'Debit line',
+    #         })]
+    #     })

--- a/account_journal_lock_date/views/journal_lock_views.xml
+++ b/account_journal_lock_date/views/journal_lock_views.xml
@@ -1,0 +1,28 @@
+<openerp>
+  <data>
+
+    <record model="ir.ui.view" id="account_journal_form_view">
+        <field name="name">account.journal.form (in account_journal_lock_date)</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <field name="type" position="after">
+                <field name="journal_lock_date"/>
+            </field>
+        </field>
+    </record>
+
+
+    <record model="ir.ui.view" id="account_journal_tree_view">
+        <field name="name">account.journal.tree (in account_journal_lock_date)</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_tree"/>
+        <field name="arch" type="xml">
+            <field name="type" position="after">
+                <field name="journal_lock_date"/>
+            </field>
+        </field>
+    </record>
+
+  </data>
+</openerp>


### PR DESCRIPTION
ref [Bloquer les encodages par journaux (achat/vente)](https://gestion.coopiteasy.be/web?debug#id=891&view_type=form&model=project.task&menu_id=338&action=479)

- add field journal_lock_date to `account.journal`
- check `account.move.accounting_date` is after journal lock date