### PR TITLE
[IMP] if unset set invoice `date` to today on write

### DIFF
--- a/invoice_default_account_date/__init__.py
+++ b/invoice_default_account_date/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/invoice_default_account_date/__openerp__.py
+++ b/invoice_default_account_date/__openerp__.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2017- Coop IT Easy.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Invoice Default Account Date",
+    "version": "1.0",
+    "depends": [
+        'account',
+    ],
+    "author": "Robin Keunen <robin@coopiteasy.be>",
+    'license': 'AGPL-3',
+    "category": "Invoice",
+    "website": "www.coopiteasy.be",
+    "summary": """
+        Sets the accounting date to the invoice date by default.
+    """,
+    'data': [
+    ],
+    'installable': True,
+}

--- a/invoice_default_account_date/models/__init__.py
+++ b/invoice_default_account_date/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_invoice

--- a/invoice_default_account_date/models/account_invoice.py
+++ b/invoice_default_account_date/models/account_invoice.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+from openerp import models, fields, api
+from datetime import date
+
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.multi
+    def write(self, vals):
+        # vendor bills
+        if (not self.date and not vals.get('date')
+            and self.type in ('in_invoice', 'in_refund')):
+
+            vals['date'] = date.today()
+
+        return super(AccountInvoice, self).write(vals)


### PR DESCRIPTION
A la création d'une facture d'achat, la date comptable doit être par défaut la date du jour d'encodage.

ref [Date comptable par défaut à la date d'encodage](https://gestion.coopiteasy.be/web#id=906&view_type=form&model=project.task&menu_id=338&action=479)