### PR TITLE
[FIX] pos rounding account inputation

### DIFF
--- a/pos_round_cash_payment_line/data/round_remainder_product.xml
+++ b/pos_round_cash_payment_line/data/round_remainder_product.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="1">
         <record id="round_remainder_product" model="product.product">
-            <field name="name">Round Remainder Product</field>
+            <field name="name">Round Remainder</field>
             <field name="categ_id" ref="product.product_category_all"/>
             <field name="uom_id" ref="product.product_uom_unit"/>
             <field name="sale_ok">1</field>


### PR DESCRIPTION
- don't round get due by 5 cents, it should return the exact value
- 5c rouding applied on prefilled cash when adding payment line
- 5c rounding applied on change values
- get_due takes change into account when computing final due
  - ie when no paymentLine passed as argument
- get due returns max(-0.02, due) to show remainder
  - more over, greater negative values were confusing alongside change
  values
- round remainder product is added after validation
  - ie when get_due < 0.025
  - when remainder of the rounding is greater than 0

\+ shorten round remainder product name to Round Remainder.