### PR TITLE
Ajout filtres

### DIFF
--- a/resource_activity/views/resource_activity_views.xml
+++ b/resource_activity/views/resource_activity_views.xml
@@ -214,9 +214,16 @@
                         domain="[('date_end', '&gt;=', time.strftime('%Y-%m-%d 00:00:00')),('date_end', '&lt;=', time.strftime('%Y-%m-%d 23:59:59'))]"/>
                     <filter name="ongoing" string="Ongoing"
                     	domain="[('date_start','&lt;=', time.strftime('%Y-%m-%d %H:%M:%S')), ('date_end','&gt;=', time.strftime('%Y-%m-%d %H:%M:%S'))]"/>
-                    	<filter name="scheduled" string="Scheduled"
+                    <filter name="scheduled" string="Scheduled"
                     	domain="[('date_start','&gt;=', time.strftime('%Y-%m-%d 00:00:00')), ('date_end','&gt;=', time.strftime('%Y-%m-%d 00:00:00'))]"/>
-                    <field name="partner_id" string="Partner"/>
+                    <filter name="coming_week" string="Today and the 7 next days"
+                    	domain="[('date_start','&gt;=', ((context_today()).strftime('%Y-%m-%d 00:00:00'))), ('date_start','&lt;=', ((context_today()+datetime.timedelta(days=7)).strftime('%Y-%m-%d 23:59:59')))]"/>
+                    <filter name="start_today" string="Start today"
+                        domain="[('date_start', '&gt;=', time.strftime('%Y-%m-%d 00:00:00')),('date_start', '&lt;=', time.strftime('%Y-%m-%d 23:59:59'))]"/>
+                    <filter name="next" string="What's next"
+                        domain="[('date_start', '&gt;=', time.strftime('%Y-%m-%d %H:%M:%S'))]"/>
+
+		    <field name="partner_id" string="Partner"/>
                     <field name="description" string="Description"/>
                     <field name="location_id" string="location" groups="resource_planning.group_multi_location"/>
                     <filter string="Draft" name="draft" domain="[('state','=','draft')]"/>
@@ -226,6 +233,9 @@
                     <separator/>
                     <filter string="Not cancelled" name="not_cancelled" domain="[('state','!=','cancelled')]"/>
                     <filter string="Cancelled" name="cancelled" domain="[('state','=','cancelled')]"/>
+                    <separator/>
+                    <filter string="Bruxelles" name="Bruxelles" domain="[('location_id','ilike','Bruxelles')]"/>
+                    <filter string="Mons" name="Bruxelles" domain="[('location_id','ilike','Mons')]"/>
                     <separator/>
                     <group string="Group By...">
                         <filter name="location" string="Location" domain="[]" context="{'group_by':'location_id'}"/>

--- a/resource_activity/views/resource_activity_views.xml
+++ b/resource_activity/views/resource_activity_views.xml
@@ -265,7 +265,7 @@
             <field name="res_model">resource.activity</field>
             <field name="view_type">form</field>
             <field name="view_mode">tree,form,calendar</field>
-            <field name="context">{"search_default_ongoing":1,"search_default_not_cancelled":1}</field>
+            <field name="context">{"search_default_coming_week":1,"search_default_not_cancelled":1}</field>
         </record>
         
         <menuitem action="action_resource_activity" id="resource_activity_menu" parent="menu_resource_activity" sequence="10"/>

--- a/resource_activity/views/resource_activity_views.xml
+++ b/resource_activity/views/resource_activity_views.xml
@@ -214,8 +214,6 @@
                         domain="[('date_end', '&gt;=', time.strftime('%Y-%m-%d 00:00:00')),('date_end', '&lt;=', time.strftime('%Y-%m-%d 23:59:59'))]"/>
                     <filter name="ongoing" string="Ongoing"
                     	domain="[('date_start','&lt;=', time.strftime('%Y-%m-%d %H:%M:%S')), ('date_end','&gt;=', time.strftime('%Y-%m-%d %H:%M:%S'))]"/>
-                    <filter name="scheduled" string="Scheduled"
-                    	domain="[('date_start','&gt;=', time.strftime('%Y-%m-%d 00:00:00')), ('date_end','&gt;=', time.strftime('%Y-%m-%d 00:00:00'))]"/>
                     <filter name="coming_week" string="Today and the 7 next days"
                     	domain="[('date_start','&gt;=', ((context_today()).strftime('%Y-%m-%d 00:00:00'))), ('date_start','&lt;=', ((context_today()+datetime.timedelta(days=7)).strftime('%Y-%m-%d 23:59:59')))]"/>
                     <filter name="start_today" string="Start today"
@@ -233,9 +231,6 @@
                     <separator/>
                     <filter string="Not cancelled" name="not_cancelled" domain="[('state','!=','cancelled')]"/>
                     <filter string="Cancelled" name="cancelled" domain="[('state','=','cancelled')]"/>
-                    <separator/>
-                    <filter string="Bruxelles" name="Bruxelles" domain="[('location_id','ilike','Bruxelles')]"/>
-                    <filter string="Mons" name="Bruxelles" domain="[('location_id','ilike','Mons')]"/>
                     <separator/>
                     <group string="Group By...">
                         <filter name="location" string="Location" domain="[]" context="{'group_by':'location_id'}"/>


### PR DESCRIPTION
Ajout de filtres et adaptation du filtre par défaut
Les filtres d'implantations (Bruxelles et Mons) sont hardcodés parce que:
1. on utilise des "pseudo-implantations" comme stocks (exemple: Bruxelles - Bike Project)
2. Toutes les implantations n'utilisent pas encore l'outil --> limitons le filtre à ce qui est pertinent.

Après, si vous avez une meilleure solution en terme de maintenabilité, n'hésitez pas.