### PR TITLE
Réparation filtre client

### DIFF
--- a/resource_activity/views/resource_activity_views.xml
+++ b/resource_activity/views/resource_activity_views.xml
@@ -230,7 +230,7 @@
                     <group string="Group By...">
                         <filter name="location" string="Location" domain="[]" context="{'group_by':'location_id'}"/>
                         <filter name="activity_type" string="Activity Type" domain="[]" context="{'group_by':'activity_type'}"/>
-                        <filter name="customer" string="Customer" domain="[]" context="{'group_by':'activity_type'}"/>
+                        <filter name="customer" string="Customer" domain="[]" context="{'group_by':'partner_id'}"/>
                     </group>
                </search>
             </field>


### PR DESCRIPTION
Sans doute un copier/coller oublié --> adapté pour filtrer effectivement sur les clients et pas le type d'activités.