### PR TITLE
[sale order report] Making the booked resource inline elements and smaller

### DIFF
--- a/resource_activity/reports/sale_order_report.xml
+++ b/resource_activity/reports/sale_order_report.xml
@@ -57,11 +57,6 @@
                 </div>
                 <div name="resources" t-if="doc.activity_id.booked_resources" class="col-xs-3">
                     <strong>Resources booked:</strong>
-                    <t t-foreach="doc.booked_resources" t-as="booked_resource">
-                        <t t-if="booked_resource">                 
-                            <span style="font-size: 8px" t-field="booked_resource.name"/>
-                        </t>                                  
-                    </t>
                 </div>
             </xpath>
                 </template>

--- a/resource_activity/reports/sale_order_report.xml
+++ b/resource_activity/reports/sale_order_report.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-	<data>
-		<template id="report_activity_saleorder_document" inherit_id="sale.report_saleorder_document">
-			<xpath expr="//div[@name='payment_term']" position="after">
+        <data>
+                <template id="report_activity_saleorder_document" inherit_id="sale.report_saleorder_document">
+                        <xpath expr="//div[@name='payment_term']" position="after">
                 <div name="date_start" t-if="doc.date_start" class="col-xs-3">
                     <strong>Start date:</strong>
                     <p t-field="doc.date_start"/>
@@ -55,15 +55,15 @@
                         </t>                                  
                     </t>
                 </div>
-		<div name="resources" t-if="doc.activity_id.booked_resources" class="col-xs-3">
+                <div name="resources" t-if="doc.activity_id.booked_resources" class="col-xs-3">
                     <strong>Resources booked:</strong>
                     <t t-foreach="doc.booked_resources" t-as="booked_resource">
                         <t t-if="booked_resource">                 
                             <span style="font-size: 8px" t-field="booked_resource.name"/>
                         </t>                                  
                     </t>
-		</div>
+                </div>
             </xpath>
-		</template>
-	</data>
+                </template>
+        </data>
 </openerp>

--- a/resource_activity/reports/sale_order_report.xml
+++ b/resource_activity/reports/sale_order_report.xml
@@ -55,14 +55,14 @@
                         </t>                                  
                     </t>
                 </div>
-                <div name="resources" t-if="doc.activity_id.booked_resources" class="col-xs-3">
+		<div name="resources" t-if="doc.activity_id.booked_resources" class="col-xs-3">
                     <strong>Resources booked:</strong>
                     <t t-foreach="doc.booked_resources" t-as="booked_resource">
                         <t t-if="booked_resource">                 
-                            <div t-field="booked_resource.name"/>
+                            <span style="font-size: 8px" t-field="booked_resource.name"/>
                         </t>                                  
                     </t>
-                </div>
+		</div>
             </xpath>
 		</template>
 	</data>


### PR DESCRIPTION
As we don't want them to take to much place and they prevented the sale orders to
render well.
Having them as block elements was not eye-pleasing to say the least.