### PR TITLE
[IMP] resource_activity: cron to set deliveries and view of deliveries

### DIFF
--- a/resource_activity/data/cron.xml
+++ b/resource_activity/data/cron.xml
@@ -13,4 +13,17 @@
       <field name="active" eval="False" />
     </record>
   </data>
+  <data noupdate="1">
+    <record id="ir_cron_set_valid_deliveries" model="ir.cron">
+      <field name="name">Set Valid Deliveries for Activities</field>
+      <field name="interval_number">12</field>
+      <field name="interval_type">months</field>
+      <field name="numbercall">-1</field>
+      <field name="doall" eval="True" />
+      <field name="model">resource.activity</field>
+      <field name="function">_set_valid_deliveries_cron</field>
+      <field name="args">()</field>
+      <field name="active" eval="False" />
+    </record>
+  </data>
 </odoo>

--- a/resource_activity/views/resource_activity_delivery_views.xml
+++ b/resource_activity/views/resource_activity_delivery_views.xml
@@ -8,13 +8,13 @@
       <field name="arch" type="xml">
         <tree string="Deliveries" delete="false" default_order="date"
           decoration-muted="state == 'draft' or state == 'cancelled'">
+          <field name="activity_id"/>
           <field name="activity_description"/>
           <field name="nb_allocated_resources"/>
           <field name="delivery_type"/>
           <field name="date"/>
           <field name="place"/>
           <field name="activity_type"/>
-          <field name="activity_id"/>
           <field name="location_id"/>
           <field name="state"/>
         </tree>
@@ -43,8 +43,7 @@
       name="Resource activity delivery"
       res_model="resource.activity.delivery"
       view_mode="tree"
-      context="{'search_default_confirmed': True,
-                'search_default_only_future': True}"/>
+      context="{'search_default_only_future': True}"/>
 
     <menuitem id="resource_activity_delivery_menu"
       name="Deliveries"


### PR DESCRIPTION
This add a script to set valid deliveries for all activities. This let
you add deliveries to already created deliveries.

And move column 'activity_id' and remove the 'confirmed' default filter.