### PR TITLE
[ADD] partner_warehouse: warehouse info on partner

### DIFF
--- a/partner_wharehouse/__init__.py
+++ b/partner_wharehouse/__init__.py
@@ -1,0 +1,1 @@
+import models

--- a/partner_wharehouse/__openerp__.py
+++ b/partner_wharehouse/__openerp__.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Business Open Source Solution
+#    Copyright (C) 2018 Coop IT Easy SCRLfs.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+{
+    "name": "Partner Warehouse",
+    "version": "9.0.1.0",
+    "depends": [
+        'base',
+        'sale',
+        'sale_stock',
+    ],
+    "author": "Rémy TAYMANS <remy@coopiteasy.be>",
+    "category": "",
+    "website": "www.coopiteasy.be",
+    "license": "AGPL-3",
+    "description": """
+    Let the warehouse of the sale order be set accordingly to a default
+    warehouse set on the partner.
+    """,
+    'data': [
+        'views/res_partner.xml',
+    ],
+    'installable': True,
+}

--- a/partner_wharehouse/models/__init__.py
+++ b/partner_wharehouse/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_partner, sale

--- a/partner_wharehouse/models/res_partner.py
+++ b/partner_wharehouse/models/res_partner.py
@@ -1,0 +1,7 @@
+from openerp import fields, models
+
+
+class Partner(models.Model):
+    _inherit = 'res.partner'
+
+    warehouse_id = fields.Many2one('stock.warehouse', 'Warehouse')

--- a/partner_wharehouse/models/sale.py
+++ b/partner_wharehouse/models/sale.py
@@ -1,0 +1,17 @@
+from openerp import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = 'sale.order'
+
+    @api.multi
+    @api.onchange('partner_id')
+    def onchange_partner_id(self):
+        """
+        Update the warehouse_id when a warehouse is set on a partner_id
+        """
+        if self.partner_id and self.partner_id.warehouse_id:
+            self.warehouse_id = self.partner_id.warehouse_id
+        else:
+            self.warehouse_id = self._default_warehouse_id()
+        super(SaleOrder, self).onchange_partner_id()

--- a/partner_wharehouse/views/res_partner.xml
+++ b/partner_wharehouse/views/res_partner.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+  <!-- Add warehouse_id field to res_partner view -->
+  <record id="view_partner_form" model="ir.ui.view">
+    <field name="model">res.partner</field>
+    <field name="inherit_id" ref="base.view_partner_form"/>
+    <field name="priority" eval="10"/>
+    <field name="arch" type="xml">
+      <xpath expr="//group[@name='sale']" position="inside">
+        <field name="warehouse_id"/>
+      </xpath>
+    </field>
+  </record>
+</odoo>


### PR DESCRIPTION
Auto fill the warehouse field on a sale order when a warehouse is
specified on a partner.

To understand the work, you may need to read these files : 
- `odoo/addons/sale_stock/sale_stock.py`
- `odoo/addons/sale/sale.py`