### PR TITLE
[FIX] unstable behaviour on invoice cancel thru refund

### DIFF
--- a/product_subscription/models/invoice.py
+++ b/product_subscription/models/invoice.py
@@ -51,7 +51,7 @@ class AccountInvoice(models.Model):
             # we check if there is an open refund for this invoice. in this case we
             # don't run the process_subscription function as the invoice has been 
             # reconciled with a refund and not a payment.
-            refund = self.search([('type','=','out_refund'),('origin','=',invoice.number)]).filtered(lambda record: record.state == 'open')
+            refund = self.search([('type','=','out_refund'),('origin','=',invoice.move_name)])
             
             if invoice.subscription and invoice.type == 'out_invoice' and not refund:
                 effective_date = datetime.now().strftime("%d/%m/%Y")


### PR DESCRIPTION
This PR try fix an unstable behaviour when you're canceling an invoice through a refund. Some time the refund tackled first, some time it's the invoice. So it lead to an refund already marked as paid and though was filtered... The process wasn't detecting that there was a canceling process and was processing the invoice matching as a paid invoice.