### PR TITLE
Les activités annulées ne doivent pas être affichées

### DIFF
--- a/resource_activity/views/resource_activity_delivery_views.xml
+++ b/resource_activity/views/resource_activity_delivery_views.xml
@@ -34,7 +34,7 @@
                      ('state', '!=', 'cancelled')]"/>
           <separator/>
           <filter name="only_future" string="Only future"
-            domain="[('date', '>=', datetime.datetime.now())]"/>
+            domain="['&amp;', ('date', '>=', datetime.datetime.now()), ('state', '!=', 'cancelled')]"/>
         </search>
       </field>
     </record>


### PR DESCRIPTION
Bonjour @robinkeunen 

Comme annoncé par mail, voici la PR d'adaptation du filtre pour la vue "deliveries".

Merci déjà d'en prendre bien soin.

A bientôt,

Jérémie