### PR TITLE
[ADD] add module stock picking auto send email

### DIFF
--- a/stock_picking_auto_send_email/__init__.py
+++ b/stock_picking_auto_send_email/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/stock_picking_auto_send_email/__manifest__.py
+++ b/stock_picking_auto_send_email/__manifest__.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# © 2017 Coop IT Easy (http://www.coopiteasy.be)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    'name': 'Stock Picking Auto Send Email',
+    'category': 'Delivery',
+    'author': "Coop IT Easy - Houssine BAKKALI <houssine@coopiteasy.be>",
+    'website': 'www.coopiteasy.be',
+    'version': '11.0.1.0.0',
+    'license': 'AGPL-3',
+    'depends': [
+        'stock',
+        'delivery',
+        'account'
+    ],
+    "description": """
+    This module allows to send confirmation email and invoice automatically
+    once the picking is done according the choosen preference.
+    """,
+    'data': [
+        'views/delivery_carrier_view.xml',
+    ],
+    'installable': True,
+}

--- a/stock_picking_auto_send_email/__manifest__.py
+++ b/stock_picking_auto_send_email/__manifest__.py
@@ -16,7 +16,7 @@
     ],
     "description": """
     This module allows to send confirmation email and invoice automatically
-    once the picking is done according the choosen preference.
+    once the picking is done according the chosen preference.
     """,
     'data': [
         'views/delivery_carrier_view.xml',

--- a/stock_picking_auto_send_email/models/__init__.py
+++ b/stock_picking_auto_send_email/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_picking
+from . import delivery_carrier

--- a/stock_picking_auto_send_email/models/delivery_carrier.py
+++ b/stock_picking_auto_send_email/models/delivery_carrier.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+from odoo import models, fields
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = 'delivery.carrier'
+
+    auto_send_picking = fields.Boolean(string="Auto send delivery mail")
+    auto_send_invoice = fields.Boolean(string="Auto send invoice mail")

--- a/stock_picking_auto_send_email/models/stock_picking.py
+++ b/stock_picking_auto_send_email/models/stock_picking.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from odoo import models, api
+
+
+class StockPicking(models.Model):
+    _inherit = 'stock.picking'
+
+    @api.multi
+    def action_done(self):
+        super(StockPicking, self).action_done()
+        picking_mail_template = self.env.ref(
+            'delivery.mail_template_data_delivery_confirmation',
+            False
+            )
+        invoice_mail_template = self.env.ref(
+            'account.email_template_edi_invoice',
+            False)
+        for picking in self:
+            sale_order = picking.sale_id
+            if sale_order.invoice_status == 'to invoice':
+                invoice_ids = sale_order.action_invoice_create()
+
+                for invoice in self.env['account.invoice'].browse(invoice_ids):
+                    invoice.action_invoice_open()
+                    # sale_order.invoice_ids.journal_id = journal_id
+                    if picking.carrier_id.auto_send_invoice:
+                        invoice_mail_template.send_mail(invoice.id)
+            if picking.carrier_id.auto_send_picking:
+                picking_mail_template.send_mail(picking.id)

--- a/stock_picking_auto_send_email/views/delivery_carrier_view.xml
+++ b/stock_picking_auto_send_email/views/delivery_carrier_view.xml
@@ -1,0 +1,13 @@
+<odoo>
+	<record id="view_delivery_carrier_form_auto_confirmation_mail" model="ir.ui.view">
+	    <field name="name">delivery.carrier.form</field>
+	    <field name="model">delivery.carrier</field>
+	    <field name="inherit_id" ref="delivery.view_delivery_carrier_form"/>
+	    <field name="arch" type="xml">
+			<field name="integration_level" position="after">
+				<field name="auto_send_picking"/>
+				<field name="auto_send_invoice"/>
+			</field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
35 - automatiser envoi de mails qd livraison faite

Automatiser l'administratif : bouton qui permet d'envoyer mail quand bon de livraison validé + facture générée, validée, et envoyée par mail automatiquement.