### PR TITLE
[FIX] medor_delivery_address: Let module be installable

### DIFF
--- a/medor_delivery_address/report/report_invoice.xml
+++ b/medor_delivery_address/report/report_invoice.xml
@@ -2,22 +2,19 @@
 <odoo>
 	<data>
 		<template id="report_invoice_document_inherit_sale" inherit_id="medor_sexy_invoice.theme_invoice_medor_document">
-	        <xpath expr="//div[@name='invoice_address']" position="attributes">
-	            <attribute name="groups">!sale.group_delivery_invoice_address</attribute>
-	        </xpath>
-	        <xpath expr="//div[@name='invoice_address']" position="before">
+	        <xpath expr="//address[@t-field='o.partner_id']/.." position="replace">
 	            <div class="col-xs-6" groups="sale.group_delivery_invoice_address">
-	                <div t-if="o.partner_shipping_id and (o.partner_shipping_id != o.partner_id)">
+	                <div t-if="o.address_shipping_id and (o.address_shipping_id != o.partner_id)">
 	                    <strong>Shipping address:</strong>
-	                    <div t-field="o.partner_shipping_id"
-	                        t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
+	                    <div t-field="o.address_shipping_id"
+	                        t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
 	                </div>
 	            </div>
-	
+
 	            <div class="col-xs-5 col-xs-offset-1" groups="sale.group_delivery_invoice_address">
 	                <div t-field="o.partner_id"
-	                    t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'/>
-	                <div t-if="o.partner_id.vat" class="mt16"><t t-esc="o.company_id.country_id.vat_label or 'TIN'"/>: <span t-field="o.partner_id.vat"/></div>
+	                    t-field-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": true}'/>
+	                <div t-if="o.partner_id.vat" class="mt16">TIN: <span t-field="o.partner_id.vat"/></div>
 	            </div>
 	        </xpath>
     	</template>

--- a/pos_printer_network/static/src/js/network_printer.js
+++ b/pos_printer_network/static/src/js/network_printer.js
@@ -352,34 +352,4 @@ odoo.define('pos_printer_network.network_printer', function (require) {
         },
     });
     gui.define_popup({name:'proxy_printers', widget: ProxyPrintersPopupWidget});
-    
-    module.ReceiptScreenWidget = module.ReceiptScreenWidget.include({
-        send : function() {
-            var self = this;
-            var loaded = new $.Deferred();
-            var order = this.pos.get_order().name;
-            var records = new Model('pos.order').call('send_order', [order], {}, { shadow: false, timeout: 10000});
-            records.then(function(result){
-                var el = self.$('.message-send')
-                el.empty();
-                el.append('<h2>' + result + '</h2>');
-            },function(err){
-                loaded.reject(err);
-            });
-        },
-        renderElement: function() {
-            var self = this;
-            this._super();
-            this.$('.button.send').click(function(){
-                if (!self._locked) {
-                    self.send();
-                }
-            });
-        },
-        show: function(){
-            this._super();
-            var self = this;
-            this.$('.message-send').empty();
-        },
-    })
 });

--- a/pos_printer_network/static/src/js/network_printer.js
+++ b/pos_printer_network/static/src/js/network_printer.js
@@ -85,9 +85,18 @@ odoo.define('pos_printer_network.network_printer', function (require) {
                                 self.receipt_queue.unshift(r);
                             });
                         }
+                        var el = self.$('.message-print')
+                        el.empty();
+                        msg += _t('Receipt printed');
+                        el.append('<h2>' + msg + '</h2>');
                     }
                 };
                 send_printing_job();
+        },
+        show: function(){
+            this._super();
+            var self = this;
+            this.$('.message-print').empty();
         },
     });
 
@@ -343,4 +352,34 @@ odoo.define('pos_printer_network.network_printer', function (require) {
         },
     });
     gui.define_popup({name:'proxy_printers', widget: ProxyPrintersPopupWidget});
+    
+    module.ReceiptScreenWidget = module.ReceiptScreenWidget.include({
+        send : function() {
+            var self = this;
+            var loaded = new $.Deferred();
+            var order = this.pos.get_order().name;
+            var records = new Model('pos.order').call('send_order', [order], {}, { shadow: false, timeout: 10000});
+            records.then(function(result){
+                var el = self.$('.message-send')
+                el.empty();
+                el.append('<h2>' + result + '</h2>');
+            },function(err){
+                loaded.reject(err);
+            });
+        },
+        renderElement: function() {
+            var self = this;
+            this._super();
+            this.$('.button.send').click(function(){
+                if (!self._locked) {
+                    self.send();
+                }
+            });
+        },
+        show: function(){
+            this._super();
+            var self = this;
+            this.$('.message-send').empty();
+        },
+    })
 });

--- a/pos_printer_network/static/src/xml/pos_printer_network.xml
+++ b/pos_printer_network/static/src/xml/pos_printer_network.xml
@@ -67,4 +67,10 @@
             </div>
         </div>
     </t>
+    <t t-extend="ReceiptScreenWidget">
+        <t t-jquery='.button print' t-operation='after'>
+	        <div class="message-print">
+            </div>
+        </t>
+    </t>
 </templates>

--- a/pos_printer_network/views/pos_printer_network_template.xml
+++ b/pos_printer_network/views/pos_printer_network_template.xml
@@ -6,13 +6,4 @@
 	        <link rel="stylesheet" href="/pos_printer_network/static/src/css/pos.css"/>
 	    </xpath>
 	</template>
-	
-	<templates id="template">
-	    <t t-extend="ReceiptScreenWidget">
-	        <t t-jquery='.button print' t-operation='after'>
-		        <div class="message-print">
-	            </div>
-	        </t>
-	    </t>
-	</templates>
 </odoo>

--- a/pos_printer_network/views/pos_printer_network_template.xml
+++ b/pos_printer_network/views/pos_printer_network_template.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <data>
-        <template id="assets_backend" name="pos_printer_network_assets" inherit_id="point_of_sale.assets">
-            <xpath expr="." position="inside">
-                <script type="text/javascript" src="/pos_printer_network/static/src/js/network_printer.js"></script>
-                <link rel="stylesheet" href="/pos_printer_network/static/src/css/pos.css"/>
-            </xpath>
-        </template>
-    </data>
+	<template id="assets_backend" name="pos_printer_network_assets" inherit_id="point_of_sale.assets">
+	    <xpath expr="." position="inside">
+	        <script type="text/javascript" src="/pos_printer_network/static/src/js/network_printer.js"></script>
+	        <link rel="stylesheet" href="/pos_printer_network/static/src/css/pos.css"/>
+	    </xpath>
+	</template>
+	
+	<templates id="template">
+	    <t t-extend="ReceiptScreenWidget">
+	        <t t-jquery='.button print' t-operation='after'>
+		        <div class="message-print">
+	            </div>
+	        </t>
+	    </t>
+	</templates>
 </odoo>

--- a/resource_activity/reports/sale_order_report.xml
+++ b/resource_activity/reports/sale_order_report.xml
@@ -19,13 +19,13 @@
                     <strong>Type:</strong>
                     <p t-field="doc.activity_type"/>
                 </div>
-                <div name="arrival" t-if="doc.arrival" class="col-xs-3">
-                    <strong>Arrival:</strong>
-                    <p t-field="doc.arrival"/>
-                </div>
                 <div name="departure" t-if="doc.departure" class="col-xs-3">
                     <strong>Departure:</strong>
                     <p t-field="doc.departure"/>
+                </div>
+                <div name="arrival" t-if="doc.arrival" class="col-xs-3">
+                    <strong>Arrival:</strong>
+                    <p t-field="doc.arrival"/>
                 </div>
                 <div name="delivery_place" t-if="doc.delivery_place" class="col-xs-3">
                     <strong>Delivery place:</strong>


### PR DESCRIPTION
Not sure what it did here… I don't understand the utility of the line:
```
<attribute name="groups">!sale.group_delivery_invoice_address</attribute>
```
It seams not to work. I understant the `!` as a negation sign but I can find other similar example.

I really don't like to do a replace in xml view. So for me a good way is to modify classes for the existing address in the sexy invoice and then add the shipping address if it is different from the address of the partner.

Also if I understand well, users that are not in the `sale.group_delivery_invoice_address` should no see any address, and so we need to generate an invoice without address.

What do you think about ?